### PR TITLE
CORE-2706: Do not use deprecated methods

### DIFF
--- a/tests/commands/test_cleanup.py
+++ b/tests/commands/test_cleanup.py
@@ -28,7 +28,7 @@ class CleanupCommandTest(BaseHelper):
         self.command.run()
 
         executed = self._get_executed_migrations()
-        self.assertEquals(
+        self.assertEqual(
             executed,
             [self.valid_filenames[0]]
         )

--- a/tests/commands/test_integration.py
+++ b/tests/commands/test_integration.py
@@ -51,7 +51,7 @@ class CommandWorkflowTest(BaseHelper):
 
         self.assertTrue(self._check_table_exist('t0'))
         self.assertTrue(self._check_table_exist('t1'))
-        self.assertEquals(self._get_executed_migrations(), self.valid_filenames)
+        self.assertEqual(self._get_executed_migrations(), self.valid_filenames)
 
     def test_cleanup(self):
         main([


### PR DESCRIPTION
`assertEquals` was deprectated on Python 2.7. Use `assertEqual`.

Chech: https://docs.python.org/2/library/unittest.html#deprecated-aliases