### PR TITLE
CORE-2707: Dont use io module in Python2

### DIFF
--- a/tests/commands/test_base.py
+++ b/tests/commands/test_base.py
@@ -7,7 +7,12 @@ from .helper import BaseHelper
 from db_utils.command.base import BaseCommand
 
 from contextlib import contextmanager
-from io import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    # do not use io for Python2 because there is some error
+    # on str/unicode
+    from io import StringIO
 
 
 @contextmanager


### PR DESCRIPTION
In Python2, the io.StringIO implementation is different than the StringIO.StringIO

This is the original exception:
```BaseCommandTest.test_check_dry_run ______________________________________________________
Traceback (most recent call last):
  File "/home/tzulberti/workspace/db-utils/tests/commands/test_base.py", line 73, in test_check_dry_run
    'DROP TABLE foobar',
  File "/home/tzulberti/workspace/db-utils/db_utils/command/base.py", line 227, in execute_sql
    self.print_sql(final_sql)
  File "/home/tzulberti/workspace/db-utils/db_utils/command/base.py", line 208, in print_sql
    print(query)
TypeError: unicode argument expected, got 'str'
```
If I use io.BytesIO instead of io.StringIO, I got the following error:

```
======================================================================
ERROR: test_check_dry_run (tests.commands.test_base.BaseCommandTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tzulberti/workspace/db-utils/tests/commands/test_base.py", line 73, in test_check_dry_run
    'DROP TABLE foobar',
  File "/home/tzulberti/workspace/db-utils/db_utils/command/base.py", line 227, in execute_sql
    self.print_sql(final_sql)
  File "/home/tzulberti/workspace/db-utils/db_utils/command/base.py", line 208, in print_sql
    print(query)
TypeError: a bytes-like object is required, not 'str'
```